### PR TITLE
Add workaround of "@ruboty job list"

### DIFF
--- a/lib/ruboty/handlers/cron.rb
+++ b/lib/ruboty/handlers/cron.rb
@@ -79,7 +79,7 @@ module Ruboty
 
       def job_descriptions
         jobs.values.map do |attributes|
-          Ruboty::Cron::Job.new(attributes).description
+          Ruboty::Cron::Job.new(attributes).description.gsub('@', '(at)')
         end.join("\n")
       end
 


### PR DESCRIPTION
`@ruboty job list`が何も表示しなくなったため調査したところ、mentionするjobが原因でした。

    @masutaka @masutaka @masutaka @masutaka 朝会やるよー

※ GitHubのmentionが飛んでしまうので、全部私にしています

この回避策で表示するようにはなりましたが、どう思われます？
AdapterはSlackです。

    1234: "05 10 * * 1-5" (at)masutaka (at)masutaka (at)masutaka (at)masutaka 朝会やるよー